### PR TITLE
fix: Moving file size check after symlink check.

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -101,12 +101,11 @@ class Index:
             for file in files:
                 path = os.path.join(root, file)
                 
-                # If the file is empty skip. 
-                if os.path.getsize(path) == 0:
-                    continue
-
                 # If the file is a symlink, don't bother
                 if os.path.islink( path ):
+                    continue
+                # If the file is empty skip. 
+                if os.path.getsize(path) == 0:
                     continue
                 # Find the language of the file.
                 language = self.language(path)

--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -100,11 +100,14 @@ class Index:
 
             for file in files:
                 path = os.path.join(root, file)
+                
+                # If the file is empty skip. 
+                if os.path.getsize(path) == 0:
+                    continue
 
                 # If the file is a symlink, don't bother
                 if os.path.islink( path ):
                     continue
-
                 # Find the language of the file.
                 language = self.language(path)
                 if language is None:


### PR DESCRIPTION
fix: Get size will fail on symlinks as the file doesn't exist. Moving the size check to come after we check for symlinks.